### PR TITLE
nuke unused resourceBundleUrl lines (caused err)

### DIFF
--- a/iOS/ReactNativeIcons/Libraries/FontAwesomeKit/FAKZocial.m
+++ b/iOS/ReactNativeIcons/Libraries/FontAwesomeKit/FAKZocial.m
@@ -9,8 +9,6 @@
 #ifndef DISABLE_ZOCIAL_AUTO_REGISTRATION
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        NSURL *resourcesBundleUrl = [[NSBundle mainBundle] URLForResource:@"ReactNativeIconsResources" withExtension:@"bundle"];
-        NSBundle *bundle = [NSBundle bundleWithURL:resourcesBundleUrl];
         [self registerIconFontWithURL: [[NSBundle mainBundle] URLForResource:@"zocial-regular-webfont" withExtension:@"ttf"]];
     });
 #endif


### PR DESCRIPTION
you removed ReactNativeIconsResources.bundle recently, so it was choking here :)

thanks for the library!
