### PR TITLE
Fix push then pop, and SMXTabBar rotation bugs.

### DIFF
--- a/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
+++ b/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
@@ -8,24 +8,6 @@
 #import "RCTWrapperViewController.h"
 #import "UIView+React.h"
 
-@interface SMXCustomTabBarController : UITabBarController <RCTViewControllerProtocol>
-
-@end
-
-@implementation SMXCustomTabBarController
-
-@synthesize currentTopLayoutGuide = _currentTopLayoutGuide;
-@synthesize currentBottomLayoutGuide = _currentBottomLayoutGuide;
-
-- (void)viewWillLayoutSubviews
-{
-  [super viewWillLayoutSubviews];
-  _currentTopLayoutGuide = self.topLayoutGuide;
-  _currentBottomLayoutGuide = self.bottomLayoutGuide;
-}
-
-@end
-
 @interface SMXTabBar() <UITabBarControllerDelegate>
 
 @end
@@ -43,7 +25,7 @@
   if ((self = [super initWithFrame:CGRectZero])) {
     _eventDispatcher = eventDispatcher;
     _tabViews = [[NSMutableArray alloc] init];
-    _tabController = [[SMXCustomTabBarController alloc] init];
+    _tabController = [[UITabBarController alloc] init];
     _tabController.delegate = self;
     [self addSubview:_tabController.view];
   }


### PR DESCRIPTION
In React Native, the RCTTabarBar was changed to work better when the device was
rotated. Unfortunately, the fix was never applied over to this library.

The original issue is in facebook/react-native#1064. This commit applies the
changes from facebook/react-native@d82aaa7fb3a69c1ee736359ac53f3b8fd583b78b back in to this library.
