### PR TITLE
peerDependencies ^ problem fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "podfile": "react-native-icons.podspec"
   },
   "peerDependencies": {
-    "react-native": "^0.5.0"
+    "react-native": ">=0.5.0 <1.0.0"
   }
 }


### PR DESCRIPTION
Thank you very much for this module. I am using it for our company's app. 

Here is a minor problem:

When running 'npm install' I got the error message

**npm ERR! peerinvalid Peer react-native-addressbook@0.1.1 wants react-native@^0.5.0**

After some googling :-) I found this discussion [special-case for 0.x in ^ is very counter-inutitive and rage-inducing #79](https://github.com/npm/node-semver/issues/79)

I changed the versioning to reflect your intended use of the caret
