### PR TITLE
Update for react-native >= 0.11

### DIFF
--- a/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
+++ b/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
@@ -77,13 +77,13 @@
 {
   // we can't hook up the VC hierarchy in 'init' because the subviews aren't
   // hooked up yet, so we do it on demand here whenever a transaction has finished
-  [self addControllerToClosestParent:_tabController];
+  [self reactAddControllerToClosestParent:_tabController];
 
   if (_tabsChanged) {
 
     NSMutableArray *viewControllers = [NSMutableArray array];
     for (SMXTabBarItem *tab in [self reactSubviews]) {
-      UIViewController *controller = tab.backingViewController;
+      UIViewController *controller = tab.reactViewController;
       if (!controller) {
         controller = [[RCTWrapperViewController alloc] initWithContentView:tab
                                                            eventDispatcher:_eventDispatcher];


### PR DESCRIPTION
This may not need to be merged right away. But it updates react-native-icons to work with the latest version of react-native (master branch)
