### PR TITLE
Add selectedImage to TabBarItemIOS

### DIFF
--- a/SMXTabBarIconItemIOS.ios.js
+++ b/SMXTabBarIconItemIOS.ios.js
@@ -31,6 +31,7 @@ var SmixxTabBarItemIOS = React.createClass({
     badgeValue: PropTypes.string,
     title: PropTypes.string,
     icon: PropTypes.object,
+    selectedIcon: PropTypes.object,
   },
 
   getInitialState: function() {
@@ -65,12 +66,20 @@ render: function() {
     tabContents = <View />;
   }
 
-  var icon = {name : this.props.iconName, size: this.props.iconSize ? this.props.iconSize : 28};
+  var iconName = this.props.iconName;
+  var iconSize = this.props.iconSize || 28;
+
+  // defaults selectedIconName to iconName, selectedIconSize to iconSize
+  var selectedIconName = this.props.selectedIconName || this.props.iconName;
+  var selectedIconSize = this.props.selectedIconSize || this.props.iconSize;
+
+  var icon = {name : iconName, size: iconSize};
+  var selectedIcon = {name: selectedIconName, size: selectedIconSize};
 
   return (
     <SmixxTabBarItem
       icon={icon}
-      selectedIcon={icon}
+      selectedIcon={selectedIcon}
       onPress={this.props.onPress}
       selected={this.props.selected}
       badgeValue={this.props.badgeValue}

--- a/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBarItemManager.m
+++ b/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBarItemManager.m
@@ -19,69 +19,90 @@ RCT_EXPORT_MODULE()
   return dispatch_get_main_queue();
 }
 
+- (UIImage *)loadIconImageUsingJSON:(id)json view:(SMXTabBarItem *)view
+{
+    NSDictionary *iconDict = json ? [RCTConvert NSDictionary:json] : [NSDictionary dictionary];
+    NSString *iconString = iconDict[@"name"];
+    UIColor *color = iconDict[@"color"] ? [RCTConvert UIColor:iconDict[@"color"]] : view.tintColor;
+    CGFloat size = [iconDict[@"size"] floatValue];
+
+    NSString *theIconName = iconString;
+    NSArray *parts = [theIconName componentsSeparatedByString:@"|"];
+    NSString *fontPrefix = parts[0];
+    NSString *iconIdentifier = parts[1];
+
+    id target;
+    if([fontPrefix isEqualToString:@"fontawesome"]) {
+        target = [FAKFontAwesome class];
+    } else if([fontPrefix isEqualToString:@"ion"]) {
+        target = [FAKIonIcons class];
+    } else if([fontPrefix isEqualToString:@"zocial"]) {
+        target = [FAKZocial class];
+    } else if([fontPrefix isEqualToString:@"foundation"]) {
+        target = [FAKFoundationIcons class];
+    } else if([fontPrefix isEqualToString:@"material"]) {
+        target = [FAKMaterial class];
+    }
+
+    SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@IconWithSize:",[self camelcase:iconIdentifier]]);
+
+    if(!target || ![target respondsToSelector:selector]) {
+        if(target) {
+            NSLog(@"No icon '%@' in '%@' icon font", iconIdentifier, fontPrefix);
+            RCTLogError(@"No icon '%@' in '%@' icon font", iconIdentifier, fontPrefix);
+        } else {
+            NSLog(@"No icon font named '%@'", fontPrefix);
+            RCTLogError(@"No icon font named '%@'", fontPrefix);
+        }
+        return nil;
+    }
+
+    NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:selector]];
+    [inv setSelector:selector];
+    [inv setTarget:target];
+    [inv setArgument:&size atIndex:2]; //arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
+    [inv retainArguments];
+    [inv invoke];
+
+    CFTypeRef result;
+    [inv getReturnValue:&result];
+
+    FAKIcon *icon = (__bridge id)result;
+    [icon setAttributes:@{NSForegroundColorAttributeName: color}];
+
+    return [icon imageWithSize:CGSizeMake(size,size)];
+}
+
 RCT_EXPORT_VIEW_PROPERTY(selected, BOOL);
 RCT_CUSTOM_VIEW_PROPERTY(icon, NSDictionary, SMXTabBarItem)
 {
     dispatch_queue_t backgroundQueue = dispatch_queue_create("com.smixxtape.reactnativeicons", 0);
     dispatch_async(backgroundQueue, ^{
-        NSDictionary *iconDict = json ? [RCTConvert NSDictionary:json] : [NSDictionary dictionary];
-        NSString *iconString = iconDict[@"name"];
-        UIColor *color = iconDict[@"color"] ? [RCTConvert UIColor:iconDict[@"color"]] : view.tintColor;
-        CGFloat size = [iconDict[@"size"] floatValue];
+        UIImage *image = [self loadIconImageUsingJSON:json view:view];
         
-        NSString *theIconName = iconString;
-        NSArray *parts = [theIconName componentsSeparatedByString:@"|"];
-        NSString *fontPrefix = parts[0];
-        NSString *iconIdentifier = parts[1];
-        
-        id target;
-        if([fontPrefix isEqualToString:@"fontawesome"]) {
-            target = [FAKFontAwesome class];
-        } else if([fontPrefix isEqualToString:@"ion"]) {
-            target = [FAKIonIcons class];
-        } else if([fontPrefix isEqualToString:@"zocial"]) {
-            target = [FAKZocial class];
-        } else if([fontPrefix isEqualToString:@"foundation"]) {
-            target = [FAKFoundationIcons class];
-        } else if([fontPrefix isEqualToString:@"material"]) {
-            target = [FAKMaterial class];
+        if (image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [view setContentMode:UIViewContentModeCenter];
+                view.barItem.image = image;
+            });
         }
-        
-        SEL selector = NSSelectorFromString([NSString stringWithFormat:@"%@IconWithSize:",[self camelcase:iconIdentifier]]);
-        
-        if(!target || ![target respondsToSelector:selector]) {
-            if(target) {
-                NSLog(@"No icon '%@' in '%@' icon font", iconIdentifier, fontPrefix);
-                RCTLogError(@"No icon '%@' in '%@' icon font", iconIdentifier, fontPrefix);
-            } else {
-                NSLog(@"No icon font named '%@'", fontPrefix);
-                RCTLogError(@"No icon font named '%@'", fontPrefix);
-            }
-            return;
-        }
-        
-        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[target methodSignatureForSelector:selector]];
-        [inv setSelector:selector];
-        [inv setTarget:target];
-        [inv setArgument:&size atIndex:2]; //arguments 0 and 1 are self and _cmd respectively, automatically set by NSInvocation
-        [inv retainArguments];
-        [inv invoke];
-        
-        CFTypeRef result;
-        [inv getReturnValue:&result];
-        
-        FAKIcon *icon = (__bridge id)result;
-        [icon setAttributes:@{NSForegroundColorAttributeName: color}];
-        
-        UIImage *image = [icon imageWithSize:CGSizeMake(size,size)];
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [view setContentMode:UIViewContentModeCenter];
-            view.barItem.image = image;
-        });
     });
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(selectedIcon, NSDictionary, SMXTabBarItem)
+{
+    dispatch_queue_t backgroundQueue = dispatch_queue_create("com.smixxtape.reactnativeicons", 0);
+    dispatch_async(backgroundQueue, ^{
+        UIImage *image = [self loadIconImageUsingJSON:json view:view];
+        
+        if (image) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [view setContentMode:UIViewContentModeCenter];
+                view.barItem.selectedImage = image;
+            });
+        }
+    });
+}
 
 RCT_REMAP_VIEW_PROPERTY(badgeValue, barItem.badgeValue, NSString);
 RCT_CUSTOM_VIEW_PROPERTY(title, NSString, SMXTabBarItem)


### PR DESCRIPTION
Fixes #90.

This PR adds the ability to provide a different icon when a tab is selected.
Example:

``` js
<TabBarIOS.Item
  name={'dashboard'}
  iconName='ion|ios-pie-outline'
  selectedIconName='ion|ios-pie'
  title='Dashboard'
  iconSize={32} // optionally provide a selectedIconSize
  selected={this._isSelected('dashboard')}
  onPress={() => this._setTab('dashboard')}>
  {this._renderDashboardContent()}
</TabBarIOS.Item>
```
