### PR TITLE
Preparing for RN >= 0.12

### DIFF
--- a/SMXIconImage.ios.js
+++ b/SMXIconImage.ios.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var React = require('react-native');
-var { StyleSheet, View, requireNativeComponent } = React;
+var { StyleSheet, View, requireNativeComponent, processColor } = React;
 var shimAssert = require('./shim-assert');
 
 var ICON_REF = 'icon';
@@ -56,7 +56,7 @@ var SMXIconImage = React.createClass({
     nativeProps.icon = {
       name: name,
       size: size,
-      color: color
+      color: processColor(color)
     };
 
     return <SMXIconImageView {...nativeProps} ref={ICON_REF} />;

--- a/SMXLoadingImage.ios.js
+++ b/SMXLoadingImage.ios.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var React = require('react-native');
-var { StyleSheet, View, requireNativeComponent, Animated, Easing } = React;
+var { StyleSheet, View, requireNativeComponent, Animated, Easing, processColor } = React;
 
 var shimAssert = require('./shim-assert');
 
@@ -85,7 +85,7 @@ var SMXLoadingImage = React.createClass({
     nativeProps.icon = {
       name: name,
       size: size,
-      color: color
+      color: processColor(color)
     };
 
     return <Animated.View style={[styles.base, style, transformStyle]}>

--- a/SMXTabBarIOS.ios.js
+++ b/SMXTabBarIOS.ios.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var React = require('react-native');
-var { StyleSheet, requireNativeComponent, PropTypes, } = React;
+var { StyleSheet, requireNativeComponent, PropTypes, processColor } = React;
 var SMXTabBarIconItemIOS = require('./SMXTabBarIconItemIOS.ios.js');
 
 var SMXTabBarIOS = React.createClass({
@@ -22,9 +22,9 @@ var SMXTabBarIOS = React.createClass({
 
   render: function () {
     var nativeProps = {
-      tintColor : this.props.tintColor,
-      barTintColor : this.props.barTintColor,
-      translucent : this.props.translucent
+      tintColor : processColor(this.props.tintColor),
+      barTintColor : processColor(this.props.barTintColor),
+      translucent : processColor(this.props.translucent)
     };
 
     return (

--- a/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
+++ b/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
@@ -85,8 +85,7 @@
     for (SMXTabBarItem *tab in [self reactSubviews]) {
       UIViewController *controller = tab.reactViewController;
       if (!controller) {
-        controller = [[RCTWrapperViewController alloc] initWithContentView:tab
-                                                           eventDispatcher:_eventDispatcher];
+        controller = [[RCTWrapperViewController alloc] initWithContentView:tab];
       }
       [viewControllers addObject:controller];
     }


### PR DESCRIPTION
#### Color processing

RN >= 0.12 moved color processing to JS, so when setting native props, it needs to use `processColor`.
#### RCTWrapperViewController method signature change

RCTWrapperViewController no longer is passed the eventDispatcher
