### PR TITLE
update initWithContentView call with eventDispatcher

### DIFF
--- a/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
+++ b/iOS/ReactNativeIcons/IconTabBarItem/SMXTabBar.m
@@ -85,7 +85,7 @@
     for (SMXTabBarItem *tab in [self reactSubviews]) {
       UIViewController *controller = tab.reactViewController;
       if (!controller) {
-        controller = [[RCTWrapperViewController alloc] initWithContentView:tab];
+        controller = [[RCTWrapperViewController alloc] initWithContentView:tab eventDispatcher:_eventDispatcher];
       }
       [viewControllers addObject:controller];
     }


### PR DESCRIPTION
I did not really look into the internals here but, using the latest v0.5-rc I was getting a `no visible interface` error on line 88 `controller = [[RCTWrapperViewController alloc] initWithContentView:tab];`

It appears react-native 0.11 no requires an eventDispatcher argument(wording?) for this method. Add the already present _eventDispatcher solved the issue (ostensibly)
