### PR TITLE
ignore examples in npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+Example


### PR DESCRIPTION
It seems to be common practise to reduce package size.
