### PR TITLE
Missing PropTypes and missing generic types

### DIFF
--- a/SMXIconImage.android.js
+++ b/SMXIconImage.android.js
@@ -47,7 +47,12 @@ var styles = StyleSheet.create({
 IconImage.propTypes = {
   name: React.PropTypes.string,
   color: React.PropTypes.string,
-  size: React.PropTypes.number
+  size: React.PropTypes.number,
+  scaleX: React.PropTypes.number,
+  scaleY: React.PropTypes.number,
+  translateX: React.PropTypes.number,
+  translateY: React.PropTypes.number,
+  rotation: React.PropTypes.number,
 };
 
 var RCTMyCustomView = requireNativeComponent('SMXIconImage', IconImage);

--- a/android/src/main/java/com/smixx/reactnativeicons/IconManager.java
+++ b/android/src/main/java/com/smixx/reactnativeicons/IconManager.java
@@ -22,7 +22,7 @@ public class IconManager extends SimpleViewManager<ReactTextView> {
     private static final Map<String, Typeface> sTypefaceCache = new HashMap<String, Typeface>();
     public static final String REACT_CLASS = "SMXIconImage";
     private static final String TAG = "IconManager";
-    private HashMap<String, IconFont> mAllIconFonts = new HashMap<>();
+    private HashMap<String, IconFont> mAllIconFonts = new HashMap<String, IconFont>();
 
     @Override
     public String getName() {

--- a/android/src/main/java/com/smixx/reactnativeicons/ReactNativeIcons.java
+++ b/android/src/main/java/com/smixx/reactnativeicons/ReactNativeIcons.java
@@ -27,7 +27,7 @@ public class ReactNativeIcons implements ReactPackage {
     }
 
     private void addIncludedFonts() {
-        mAllIconFonts = new ArrayList<>(Arrays.<IconFont>asList(
+        mAllIconFonts = new ArrayList<IconFont>(Arrays.<IconFont>asList(
                 new IconFont("fontawesome", "FontAwesome.otf"),
                 new IconFont("ion", "ionicons.ttf"),
                 new IconFont("zocial", "zocial.ttf"),
@@ -39,7 +39,7 @@ public class ReactNativeIcons implements ReactPackage {
     @Override
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
-        return new ArrayList<>();
+        return new ArrayList<NativeModule>();
     }
 
     @Override


### PR DESCRIPTION
I couldn't get the latest version to build, the java compiler was complaining that it could not infer the types of those ArrayLists and the HashMap, so I manually added them.

On top of that, React was complaining about missing PropTypes for the native modules' props, so I added those as well.

With these changes it's working for me now.
