### PR TITLE
React-Native 0.16.0 complained about missing PropTypes on Android.

### DIFF
--- a/SMXIconImage.android.js
+++ b/SMXIconImage.android.js
@@ -53,6 +53,13 @@ IconImage.propTypes = {
   translateX: React.PropTypes.number,
   translateY: React.PropTypes.number,
   rotation: React.PropTypes.number,
+  renderToHardwareTextureAndroid: React.PropTypes.bool,
+  onLayout: React.PropTypes.bool,
+  accessibilityLiveRegion: React.PropTypes.string,
+  accessibilityComponentType: React.PropTypes.string,
+  importantForAccessibility: React.PropTypes.string,
+  accessibilityLabel: React.PropTypes.string,
+  testID: React.PropTypes.string,
 };
 
 var RCTMyCustomView = requireNativeComponent('SMXIconImage', IconImage);


### PR DESCRIPTION
The few-hours-old RN 0.16.0 complains about missing PropTypes on Android (see attached screenshot). I just added all of them until my application was able to start again. Feel free to accept, reject or comment this fix :smiley:

![2015-12-04 19 37 28](https://cloud.githubusercontent.com/assets/6161006/11599453/4967ff4c-9ac7-11e5-9606-4fe52b5868a6.png)
