### PR TITLE
Incorrect import as of latest react native

### DIFF
--- a/android/src/main/java/com/smixx/reactnativeicons/IconManager.java
+++ b/android/src/main/java/com/smixx/reactnativeicons/IconManager.java
@@ -5,7 +5,7 @@ import android.graphics.Typeface;
 import android.util.Log;
 import android.view.Gravity;
 
-import com.facebook.react.uimanager.ReactProp;
+import com.facebook.react.uimanager.annotations.ReactProp;
 import com.facebook.react.uimanager.SimpleViewManager;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.views.text.ReactTextView;


### PR DESCRIPTION
import com.facebook.react.uimanager.ReactProp;  
changed to ->
import com.facebook.react.uimanager.annotations.ReactProp;